### PR TITLE
Styles for code highlighting

### DIFF
--- a/styles/dark.css
+++ b/styles/dark.css
@@ -14,6 +14,34 @@
     --background-tile: url("/res/img/tiles_dark.png");
     --link-color: #99b;
     --shadow: rgba(0, 0, 0, 0.5);
+
+    /* THIS IS THE SBHIGHLIGHT SECTION */
+    /*
+      NOTE: "function" means "built-in function OR VARIABLE"
+      (actual functions use the "statement" classname)
+      This is for backwards compatibility with the old CSS.
+      old SBhighlight couldn't tell functions and variables apart,
+      and "function" was used for all builtins.
+    */
+    /* some vars duplicate color because that's how i want default */
+    --highlight-bg: #000000;
+    --highlight-text: #eeeeee;
+    --highlight-string: #59ee79;
+    --highlight-number: #f359ab;
+    --highlight-keyword: #2494f0;
+    --highlight-question: #2494f0;
+    --highlight-kwoperator: #2494f0;
+    --highlight-tostep: #2494f0;
+    --highlight-constant: #aeb5c2;
+    --highlight-comment: #a1f198;
+    --highlight-label: #f4963e;
+    --highlight-variable: #fbf4cb;
+    --highlight-builtin: #8d7ff5;
+    --highlight-statement: #7ff5ef;
+    --highlight-defname: #7ff5ef;
+    --highlight-backslash: #777777;
+    --highlight-operator: #eeeeee;
+    --highlight-equals: #eeeeee;
 }
 
 :root[data-theme="dark"] #content input:not([type="checkbox"]):not([type="submit"]), :root[data-theme="dark"] textarea {

--- a/styles/global.css
+++ b/styles/global.css
@@ -988,7 +988,7 @@ div.comments-list {
 }
 
 .bbcode-view code {
-    font-family: 'Courier New', Courier, monospace, "SMILEBASIC";
+    font-family: monospace, "SMILEBASIC";
     font-size: 1em;
     display: inline;
     white-space: pre-wrap;
@@ -996,8 +996,8 @@ div.comments-list {
 
 .bbcode-view code:not([data-inline]) {
     display: block;
-    background: black;
-    color: white;
+    background-color: var(--highlight-bg);
+    color: var(--highlight-text);
     padding: .5em;
     box-shadow: 2px 2px 5px var(--shadow);
     margin-bottom: 1em;
@@ -1333,6 +1333,34 @@ h2.crumbs {
     transform: rotate(315deg) translate(0, -35px) scale(0.1);
     opacity: 0.1;
 }
+
+/* == Apply Highlighter Colors == */
+.bbcode-view code:not([data-inline]) span.keyword {
+    font-weight: bold;
+    color: var(--highlight-keyword);
+}
+.bbcode-view code:not([data-inline]) span.question {
+    font-weight: bold;
+    color: var(--highlight-question);
+}
+.bbcode-view code:not([data-inline]) span.to-step {
+    font-weight: bold;
+    color: var(--highlight-tostep);
+}
+.bbcode-view code:not([data-inline]) span.string { color: var(--highlight-string); }
+.bbcode-view code:not([data-inline]) span.number { color: var(--highlight-number); }
+.bbcode-view code:not([data-inline]) span.constant { color: var(--highlight-constant); }
+.bbcode-view code:not([data-inline]) span.label { color: var(--highlight-label); }
+.bbcode-view code:not([data-inline]) span.variable { color: var(--highlight-variable); }
+.bbcode-view code:not([data-inline]) span.comment { color: var(--highlight-comment); }
+.bbcode-view code:not([data-inline]) span.statement { color: var(--highlight-statement); }
+.bbcode-view code:not([data-inline]) span.function { color: var(--highlight-builtin); }
+.bbcode-view code:not([data-inline]) span.name { color: var(--highlight-defname); }
+.bbcode-view code:not([data-inline]) span.whitespace { color: var(--highlight-backslash); }
+.bbcode-view code:not([data-inline]) span.operator { color: var(--highlight-operator); }
+.bbcode-view code:not([data-inline]) span.word-operator { color: var(--highlight-kwoperator); }
+.bbcode-view code:not([data-inline]) span.equals { color: var(--highlight-equals); }
+/* ==== */
 
 @media only screen and (max-width: 1280px) {
     #content {

--- a/styles/light.css
+++ b/styles/light.css
@@ -14,6 +14,34 @@
     --background-tile: url("/res/img/tiles_light.png");
     --link-color: #66c;
     --shadow: rgba(0, 0, 0, 0.5);
+
+    /* THIS IS THE SBHIGHLIGHT SECTION */
+    /*
+      NOTE: "function" means "built-in function OR VARIABLE"
+      (actual functions use the "statement" classname)
+      This is for backwards compatibility with the old CSS.
+      old SBhighlight couldn't tell functions and variables apart,
+      and "function" was used for all builtins.
+    */
+    /* some vars duplicate color because that's how i want default */
+    --highlight-bg: #F8F8F8F8;
+    --highlight-text: #000000;
+    --highlight-string: #009e25;
+    --highlight-number: #e9077f;
+    --highlight-keyword: #0081eb;
+    --highlight-question: #0081eb;
+    --highlight-kwoperator: #0081eb;
+    --highlight-tostep: #0081eb;
+    --highlight-constant: #47546c;
+    --highlight-comment: #366f2f;
+    --highlight-label: #fa7900;
+    --highlight-variable: #3b3308;
+    --highlight-builtin: #6646f6;
+    --highlight-statement: #04867f;
+    --highlight-defname: #04867f;
+    --highlight-backslash: #888888;
+    --highlight-operator: #000000;
+    --highlight-equals: #000000;
 }
 
 /* @supports (backdrop-filter: none) or (-webkit-backdrop-filter: none) {


### PR DESCRIPTION
- Added CSS color variables for syntax highlighting in `dark.css` and `light.css`
- Added/changed rules in `global.css` to apply coloring to syntax tags
- Removed Courier from font stack, because it's awful and every decent browser knows what `monospace` means

Feel free to review the color choices (especially light theme) before including in production.